### PR TITLE
Sprint 2 cleaning configs

### DIFF
--- a/2015-tm22-dev-sprint-02/model_config.toml
+++ b/2015-tm22-dev-sprint-02/model_config.toml
@@ -45,20 +45,26 @@
     use_emme_logbook = true
 
 [household]
-    highway_demand_file = "demand_matrices/highway/household/TAZ_Demand_{period}_{iter}.omx"
-    active_demand_file = "demand_matrices/active/nm_demand_{period}.omx"
-    transit_demand_file = "demand_matrices/transit/trn_demand_{period}.omx" #temp name format, add iteration?
+    # raw demand matrices from ctramp
     highway_taz_ctramp_output_file = "ctramp_output/{mode_agg}_{period}_{mode}_{period}.omx"
     highway_maz_ctramp_output_file = "ctramp_output/auto_{period}_MAZ_AUTO_{number}_{period}.omx"
     transit_tap_ctramp_output_file = "ctramp_output/{mode_agg}_{period}_{mode}_TRN_{set}_{period}.omx"
 	transit_taz_ctramp_output_file = "ctramp_output/{mode_agg}_{period}_{mode}_TRN_{period}.omx"
+
+    # raw trip lists from ctramp
     ctramp_indiv_trip_file = "ctramp_output/indivTripData_{iteration}.csv"
     ctramp_joint_trip_file = "ctramp_output/jointTripData_{iteration}.csv"
-	ctramp_run_dir = 'ctramp_output'	
+	ctramp_run_dir = 'ctramp_output'
     OwnedAV_ZPV_factor = 0.7
     TNC_ZPV_factor = 0.7
 	ctramp_hh_file = "ctramp_output/householdData_{iteration}.csv"
+
+    # demand matrices for assignment
+    highway_demand_file = "demand_matrices/highway/household/TAZ_Demand_{period}_{iter}.omx"
+    active_demand_file = "demand_matrices/active/nm_demand_{period}.omx"
+    transit_demand_file = "demand_matrices/transit/trn_demand_{period}_{iter}.omx"
 	
+    # consolidate individual single-page OMXs into one OMXs
     [[household.mode_agg]]
         name = "auto"
         modes = [
@@ -1612,283 +1618,4 @@
     headway_fraction = 0.1
     transfer_wait_perception_factor = 3.5
 
-# [[transit.vehicles]]
-#     vehicle_id = 12
-#     mode = "b"
-#     name = ""
-#     auto_equivalent = 2.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 14
-#     mode = "b"
-#     name = ""
-#     auto_equivalent = 2.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 13
-#     mode = "b"
-#     name = ""
-#     auto_equivalent = 2.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 16
-#     mode = "b"
-#     name = ""
-#     auto_equivalent = 2.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 17
-#     mode = "b"
-#     name = ""
-#     auto_equivalent = 2.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 20
-#     mode = "b"
-#     name = ""
-#     auto_equivalent = 2.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 21
-#     mode = "b"
-#     name = ""
-#     auto_equivalent = 2.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 24
-#     mode = "b"
-#     name = ""
-#     auto_equivalent = 2.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 28
-#     mode = "b"
-#     name = ""
-#     auto_equivalent = 2.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 30
-#     mode = "b"
-#     name = ""
-#     auto_equivalent = 2.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 38
-#     mode = "b"
-#     name = ""
-#     auto_equivalent = 2.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 42
-#     mode = "b"
-#     name = ""
-#     auto_equivalent = 2.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 44
-#     mode = "b"
-#     name = ""
-#     auto_equivalent = 2.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 46
-#     mode = "b"
-#     name = ""
-#     auto_equivalent = 2.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 49
-#     mode = "b"
-#     name = ""
-#     auto_equivalent = 2.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 52
-#     mode = "b"
-#     name = ""
-#     auto_equivalent = 2.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 56
-#     mode = "b"
-#     name = ""
-#     auto_equivalent = 2.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 60
-#     mode = "b"
-#     name = ""
-#     auto_equivalent = 2.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 63
-#     mode = "b"
-#     name = ""
-#     auto_equivalent = 2.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 66
-#     mode = "b"
-#     name = ""
-#     auto_equivalent = 2.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 68
-#     mode = "b"
-#     name = ""
-#     auto_equivalent = 2.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 70
-#     mode = "b"
-#     name = ""
-#     auto_equivalent = 2.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 71
-#     mode = "b"
-#     name = ""
-#     auto_equivalent = 2.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 80
-#     mode = "x"
-#     name = ""
-#     auto_equivalent = 2.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 81
-#     mode = "x"
-#     name = ""
-#     auto_equivalent = 2.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 84
-#     mode = "x"
-#     name = ""
-#     auto_equivalent = 2.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 86
-#     mode = "x"
-#     name = ""
-#     auto_equivalent = 2.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 87
-#     mode = "x"
-#     name = ""
-#     auto_equivalent = 2.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 90
-#     mode = "x"
-#     name = ""
-#     auto_equivalent = 2.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 91
-#     mode = "x"
-#     name = ""
-#     auto_equivalent = 2.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 92
-#     mode = "x"
-#     name = ""
-#     auto_equivalent = 2.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 94
-#     mode = "x"
-#     name = ""
-#     auto_equivalent = 2.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 101
-#     mode = "f"
-#     name = ""
-#     auto_equivalent = 0.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 103
-#     mode = "f"
-#     name = ""
-#     auto_equivalent = 0.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 110
-#     mode = "l"
-#     name = ""
-#     auto_equivalent = 0.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 111
-#     mode = "l"
-#     name = ""
-#     auto_equivalent = 0.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 120
-#     mode = "h"
-#     name = ""
-#     auto_equivalent = 0.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 130
-#     mode = "r"
-#     name = ""
-#     auto_equivalent = 0.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 131
-#     mode = "r"
-#     name = ""
-#     auto_equivalent = 0.0
-#     seated_capacity = 1
-#     total_capacity = 2
-# [[transit.vehicles]]
-#     vehicle_id = 133
-#     mode = "r"
-#     name = ""
-#     auto_equivalent = 0.0
-#     seated_capacity = 1
-#     total_capacity = 2
+# transit vehicle type data associated to each transit line in Lasso, when writing out to emmebank

--- a/2015-tm22-dev-sprint-02/model_config.toml
+++ b/2015-tm22-dev-sprint-02/model_config.toml
@@ -45,12 +45,6 @@
     use_emme_logbook = true
 
 [household]
-    # raw demand matrices from ctramp
-    highway_taz_ctramp_output_file = "ctramp_output/{mode_agg}_{period}_{mode}_{period}.omx"
-    highway_maz_ctramp_output_file = "ctramp_output/auto_{period}_MAZ_AUTO_{number}_{period}.omx"
-    transit_tap_ctramp_output_file = "ctramp_output/{mode_agg}_{period}_{mode}_TRN_{set}_{period}.omx"
-	transit_taz_ctramp_output_file = "ctramp_output/{mode_agg}_{period}_{mode}_TRN_{period}.omx"
-
     # raw trip lists from ctramp
     ctramp_indiv_trip_file = "ctramp_output/indivTripData_{iteration}.csv"
     ctramp_joint_trip_file = "ctramp_output/jointTripData_{iteration}.csv"

--- a/2015-tm22-dev-sprint-02/model_config.toml
+++ b/2015-tm22-dev-sprint-02/model_config.toml
@@ -523,12 +523,6 @@
         max_dist_miles = 3
         output = "skim_matrices/non_motorized/ped_distance_maz_maz.txt"
     [[active_modes.shortest_path_skims]]
-        mode = "walk"
-        roots = "MAZ"
-        leaves = "TAP"
-        max_dist_miles = 0.5
-        output = "skim_matrices/non_motorized/ped_distance_maz_tap.txt"
-    [[active_modes.shortest_path_skims]]
         mode = "bike"
         roots = "MAZ"
         leaves = "MAZ"
@@ -536,21 +530,9 @@
         output = "skim_matrices/non_motorized/bike_distance_maz_maz.txt"
     [[active_modes.shortest_path_skims]]
         mode = "bike"
-        roots = "MAZ"
-        leaves = "TAP"
-        max_dist_miles = 3
-        output = "skim_matrices/non_motorized/bike_distance_maz_tap.txt"
-    [[active_modes.shortest_path_skims]]
-        mode = "bike"
         roots = "TAZ"
         leaves = "TAZ"
         output = "skim_matrices/non_motorized/bike_distance_taz_taz.txt"
-    [[active_modes.shortest_path_skims]]
-        mode = "walk"
-        roots = "TAP"
-        leaves = "TAP"
-        max_dist_miles = 0.5
-        output = "skim_matrices/non_motorized/ped_distance_tap_tap.txt"
 
 [highway]
     drive_access_output_skim_path = "skim_matrices\\transit\\drive_access\\drive_maz_taz_tap.csv"
@@ -1618,4 +1600,4 @@
     headway_fraction = 0.1
     transfer_wait_perception_factor = 3.5
 
-# transit vehicle type data associated to each transit line in Lasso, when writing out to emmebank
+# transit vehicle type data are associated with each transit line in Lasso, when writing out to emmebank

--- a/2015-tm22-dev-sprint-02/model_config.toml
+++ b/2015-tm22-dev-sprint-02/model_config.toml
@@ -535,17 +535,17 @@
         output = "skim_matrices/non_motorized/bike_distance_taz_taz.txt"
 
 [highway]
-    drive_access_output_skim_path = "skim_matrices\\transit\\drive_access\\drive_maz_taz_tap.csv"
     output_skim_path = "skim_matrices/highway"
     output_skim_filename_tmpl = "HWYSKM{time_period}_taz.omx"
     output_skim_matrixname_tmpl = "{time_period}_{mode}_{property}"
+    # convergence criteria
     relative_gap = 0.0005
     max_iterations = 100
     # labels entire highway network (any of the classes) + MAZ connectors
     generic_highway_mode_code = "c"
     # include other MAZs to estimate density (pop+jobs*2.5)/acres for each MAZ
     area_type_buffer_dist_miles = 0.5
-    # nodes at interchanges
+    # nodes at interchanges, for highway reliability calculation
     interchange_nodes_file = "inputs/hwy/interchange_nodes.csv"
     [highway.tolls]
         file_path = "inputs/hwy/tolls.csv"

--- a/2015-tm22-dev-sprint-02/model_config.toml
+++ b/2015-tm22-dev-sprint-02/model_config.toml
@@ -58,28 +58,6 @@
     active_demand_file = "demand_matrices/active/nm_demand_{period}.omx"
     transit_demand_file = "demand_matrices/transit/trn_demand_{period}_{iter}.omx"
 	
-    # consolidate individual single-page OMXs into one OMXs
-    [[household.mode_agg]]
-        name = "auto"
-        modes = [
-            "SOV_GP",
-            "SOV_PAY",
-            "SR2_GP",
-            "SR2_HOV",
-            "SR2_PAY",
-            "SR3_GP",
-            "SR3_HOV",
-            "SR3_PAY",
-        ]
-    [[household.mode_agg]]
-        name = "nonmotor"
-        modes = ["BIKE", "WALK"]
-    [[household.mode_agg]]
-        name = "other"
-        modes = ["SCHLBUS", "TAXI", "TNC"]
-    [[household.mode_agg]]
-        name = "transit"
-        modes = ["KNRPRV", "KNRTNC", "PNR", "WLK"]
     [household.rideshare_mode_split]
         "taxi"=0.08
         "single_tnc"=0.72

--- a/2015-tm22-dev-sprint-02/model_config.toml
+++ b/2015-tm22-dev-sprint-02/model_config.toml
@@ -781,7 +781,6 @@
     # default transit speed used to calculate transit time in case any links has missing time from highway network
     transit_speed = 30.0 
     effective_headway_source = "hdw"
-	headway_fraction = 0.5
     initial_wait_perception_factor = 1.5
     transfer_wait_perception_factor = 3.5
     walk_perception_factor = 2.0

--- a/2015-tm22-dev-sprint-02/scenario_config.toml
+++ b/2015-tm22-dev-sprint-02/scenario_config.toml
@@ -21,7 +21,6 @@
         #"highway",
         #"highway_maz_skim",
         #"prepare_network_transit", 
-        #"drive_access_skims", 
         #"transit_assign", 
         #"transit_skim" 
     ]


### PR DESCRIPTION
Reviewing and cleaning model config and scenario config

- [x] Remove TAP-related settings
- [x] Remove drive to TAP skims
- [x] Remove the commented-out transit vehicle definitions
- [x] Remove demand matrices written out by CTRAMP, as we are now processing demand directly in tm2py using trip lists from CTRAMP.
- [x] Add comments to help users
- [x] Remove transit.headway_fraction. It was replaced by transit.modes.headway_fraction.

This PR uses code changes in: https://github.com/BayAreaMetro/tm2py/pull/159, together they address https://github.com/BayAreaMetro/tm2py/issues/157